### PR TITLE
docs: ✏️ README typo fix, enforce pnpm pkg mng, update node v

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ yarn-error.log*
 .chatgpt-md-translator
 .prompt.md
 translate.sh
+
+# other package manager lock files
+package-lock.json
+yarn.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ cd docs;
 
 ### Installing Node.js and Pnpm
 
-Berachain docs uses Pnpm workspaces to manage multiple projects. You need to install Node.js v18 or higher and Pnpm v8.15.0 or higher.
+Berachain docs uses Pnpm workspaces to manage multiple projects. You need to install Node.js v20 or higher and Pnpm v8.15.0 or higher.
 
 You can run the following commands in your terminal to check your local Node.js and Pnpm versions:
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@ This is a monolithic repository that contains all the documentation for Berachai
 
 ## Requirements
 
-- NVM or Node `v18.18.2+`
+- NVM or Node `v20.11.0` or greater
 - pnpm (recommended)
 
 ## Turborepo Folder Structure
 
 This Turborepo includes the following packages/apps:
 
-### Apps
+### Docs
+
+All docs are built with [Vitepress](https://vitepress.dev) - Vite & Vue Powered Static Site Generator.
 
 - `apps/bend`- Main docs repository for [https://docs.bend.berachain.com](https://docs.bend.berachain.com)
 - `apps/berps`- Main docs repository for [https://docs.berps.berachain.com](https://docs.berps.berachain.com)
@@ -20,7 +22,7 @@ This Turborepo includes the following packages/apps:
 
 ### Packages
 
-A series of packages that are shared with various `apps`.
+A series of packages that are shared with various `apps` (doc sites).
 
 - `packages/ui`: All Vitepress vue components used by the different doc apps.
 - `packages/config`: All configurations and constants
@@ -60,11 +62,11 @@ pnpm dev --filter @berachain/core;
 
 ### Code Of Conduct
 
-Plesae see [Code of Conduct](CODE_OF_CONDUCT.md)
+Please see [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ### Contributing Guide
 
-Please see [CONTRIBUTING.md](CONTRIBUTING.md) for how to contribute and also see the [development workflow](CONTRIBUTING.md#development-workflow).
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) on how to contribute and also see the [development workflow](CONTRIBUTING.md#development-workflow).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "scripts": {
+    "preinstall": "npx only-allow pnpm",
     "build": "turbo run build",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
@@ -19,7 +20,7 @@
     "prettier": "^2.8.8",
     "turbo": "latest"
   },
-  "packageManager": "pnpm@7.15.0",
+  "packageManager": "pnpm@8.15.0",
   "name": "docs-monorepo",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Description

Updated README with typos, mentioning vitepress and vue, enforced pnpm as package manager, and updated docs to enforce node v20

BREAKING CHANGE: 🧨 No

## Contribution

- [x] I have followed the [Development Workflow](https://github.com/berachain/docs/blob/main/CONTRIBUTING.md#development-workflow)
- [x] I have read the [CODE OF CONDUCT](https://github.com/berachain/docs/blob/main/CODE_OF_CONDUCT.md)

Let us know your wallet address/ENS:

```
codingwithmanny.eth
```
