### PR TITLE
docs: ✏️ Add GoldRush (by Covalent) link to Developer Tools

### DIFF
--- a/apps/core/CHANGELOG.md
+++ b/apps/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @berachain/core
 
+## 1.1.6
+
+### Patch Changes
+
+- Add GoldRush (by Covalent) link to Developer Tools
+
 ## 1.1.5
 
 ### Patch Changes

--- a/apps/core/content/developers/developer-tools.md
+++ b/apps/core/content/developers/developer-tools.md
@@ -52,10 +52,11 @@ Since Berachain is EVM-compatible, if you're familiar with creating Dapps on oth
 
 and a [full Geth JSON-RPC interface](https://geth.ethereum.org/docs/interacting-with-geth/rpc) for calling the chain.
 
-### Subgraphs
+### Subgraphs & Data Indexers
 
 - [Goldsky](https://goldsky.com)
 - [Ghost Graph](https://ghostgraph.xyz)
+- [GoldRush (powered by Covalent)](https://goldrush.dev/docs/networks/berachain-testnet/)
 
 ### Oracles
 

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@berachain/core",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "scripts": {
     "dev": "vitepress dev --port 5173",
     "build": "vitepress build",


### PR DESCRIPTION
Since Covalent now indexes Berachain bArtio, adding GoldRush to the list developer tools available for builders.

## Description

What changes are made in this PR? Is it a feature or a bug fix?

Does it close a specific issue?

Example:

```
Closes #1
```

## Contribution

- [X] I have followed the [Development Workflow](https://github.com/berachain/docs/blob/main/CONTRIBUTING.md#development-workflow)
- [X] I have read the [CODE OF CONDUCT](https://github.com/berachain/docs/blob/main/CODE_OF_CONDUCT.md)

Let us know your wallet address/ENS:

```
0xYourAddress
```
