### PR TITLE
docs: Corrected Docs Typos

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,10 +16,10 @@ Closes #1
 - [ ] I have read the [CODE OF CONDUCT](https://github.com/berachain/docs/blob/main/CODE_OF_CONDUCT.md)
 
 - [ ] I HAVE MADE SURE TO ALLOW MAINTAINERS TO EDIT THIS PULL REQUEST
-<img src="https://raw.githubusercontent.com/berachain/docs/refs/heads/main/.github/assets/allow-edits-by-maintainers.png" alt="Allow Maintainers to Edit" width="300px"/>
+      <img src="https://raw.githubusercontent.com/berachain/docs/refs/heads/main/.github/assets/allow-edits-by-maintainers.png" alt="Allow Maintainers to Edit" width="300px"/>
 
 - [ ] I have synced my fork so that it is up to date with the latest changes
-<img src="https://raw.githubusercontent.com/berachain/docs/refs/heads/main/.github/assets/synced-fork.png" alt="Synced Fork With Remote Upstream" width="300px"/>
+      <img src="https://raw.githubusercontent.com/berachain/docs/refs/heads/main/.github/assets/synced-fork.png" alt="Synced Fork With Remote Upstream" width="300px"/>
 
 Let us know your wallet address/ENS:
 

--- a/apps/bend/content/developers/contracts/pool.md
+++ b/apps/bend/content/developers/contracts/pool.md
@@ -126,11 +126,11 @@ function repay(address asset, uint256 amount, uint256 interestRateMode, address 
 
 **Parameters**
 
-| Name               | Type      | Description                                                                                                                                                                                                                              |
-| ------------------ | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `asset`            | `address` | The address of the borrowed underlying asset previously borrowed                                                                                                                                                                         |
-| `amount`           | `uint256` | The amount to repay - Send the value type(uint256).max in order to repay the whole debt for `asset` on the specific `debtMode`                                                                                                           |
-| `interestRateMode` | `uint256` | The interest rate mode at of the debt the user wants to repay: 1 for Stable, 2 for Variable                                                                                                                                              |
+| Name               | Type      | Description                                                                                                                                                                                                                        |
+| ------------------ | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `asset`            | `address` | The address of the borrowed underlying asset previously borrowed                                                                                                                                                                   |
+| `amount`           | `uint256` | The amount to repay - Send the value type(uint256).max in order to repay the whole debt for `asset` on the specific `debtMode`                                                                                                     |
+| `interestRateMode` | `uint256` | The interest rate mode at of the debt the user wants to repay: 1 for Stable, 2 for Variable                                                                                                                                        |
 | `onBehalfOf`       | `address` | The address of the user who will get his debt reduced/removed. Should be the address of the user calling the function if he wants to reduce/remove his own debt, or the address of any other borrower whose debt should be removed |
 
 **Returns**
@@ -159,16 +159,16 @@ function repayWithPermit(
 
 **Parameters**
 
-| Name               | Type      | Description                                                                                                                                                                                                                          |
-| ------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `asset`            | `address` | The address of the borrowed underlying asset previously borrowed                                                                                                                                                                     |
-| `amount`           | `uint256` | The amount to repay - Send the value type(uint256).max in order to repay the whole debt for `asset` on the specific `debtMode`                                                                                                       |
-| `interestRateMode` | `uint256` | The interest rate mode at of the debt the user wants to repay: 1 for Stable, 2 for Variable                                                                                                                                          |
+| Name               | Type      | Description                                                                                                                                                                                                                    |
+| ------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `asset`            | `address` | The address of the borrowed underlying asset previously borrowed                                                                                                                                                               |
+| `amount`           | `uint256` | The amount to repay - Send the value type(uint256).max in order to repay the whole debt for `asset` on the specific `debtMode`                                                                                                 |
+| `interestRateMode` | `uint256` | The interest rate mode at of the debt the user wants to repay: 1 for Stable, 2 for Variable                                                                                                                                    |
 | `onBehalfOf`       | `address` | Address of the user who will get his debt reduced/removed. Should be the address of the user calling the function if he wants to reduce/remove his own debt, or the address of any other borrower whose debt should be removed |
-| `deadline`         | `uint256` | The deadline timestamp that the permit is valid                                                                                                                                                                                      |
-| `permitV`          | `uint8`   | The V parameter of ERC712 permit sig                                                                                                                                                                                                 |
-| `permitR`          | `bytes32` | The R parameter of ERC712 permit sig                                                                                                                                                                                                 |
-| `permitS`          | `bytes32` | The S parameter of ERC712 permit sig                                                                                                                                                                                                 |
+| `deadline`         | `uint256` | The deadline timestamp that the permit is valid                                                                                                                                                                                |
+| `permitV`          | `uint8`   | The V parameter of ERC712 permit sig                                                                                                                                                                                           |
+| `permitR`          | `bytes32` | The R parameter of ERC712 permit sig                                                                                                                                                                                           |
+| `permitS`          | `bytes32` | The S parameter of ERC712 permit sig                                                                                                                                                                                           |
 
 **Returns**
 

--- a/apps/berps/CHANGELOG.md
+++ b/apps/berps/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @berachain/berps
 
+## 1.1.5
+
+### Patch Changes
+
+- Typo correction for Berachain
+
 ## 1.1.4
 
 ### Patch Changes

--- a/apps/berps/content/learn/index.md
+++ b/apps/berps/content/learn/index.md
@@ -4,7 +4,7 @@
 
 # What Is Berachain Berps 🐻⛓️
 
-Berachain Berps is a native Berchain dApp that is a decentralized leveraged trading platform which allows for perpetual futures contract trading.
+Berachain Berps is a native Berachain dApp that is a decentralized leveraged trading platform which allows for perpetual futures contract trading.
 
 Berps allows for low trading fees on a vartiery of pairs (e.g. ETH-USDC) with leverages of up to 100x. This means with 10 `$HONEY` you can place a trade up to 100x which would equate to a position size of 1000 `$HONEY` (excluding fees).
 

--- a/apps/berps/content/learn/leveraged-trading/index.md
+++ b/apps/berps/content/learn/leveraged-trading/index.md
@@ -6,7 +6,7 @@
 
 Leveraged trading is a strategy that involves using borrowed money to increase the potential rewards. In the case of Berps, traders use leverage to amplify their buying power, allowing them to make larger trades than their own capital would normally permit. However, while it can magnify rewards, it also increases the potential for significant losses, making it a high-risk trading strategy.
 
-<a target="_blank" :href="config.testnet.dapps.berps.url">![Berchain Native Perps](/assets/berachain-berps-dashboard.png)</a>
+<a target="_blank" :href="config.testnet.dapps.berps.url">![Berachain Native Perps](/assets/berachain-berps-dashboard.png)</a>
 
 > {{config.testnet.dapps.berps.name}} can be found at <a target="_blank" :href="config.testnet.dapps.berps.url">{{config.testnet.dapps.berps.url}}</a>
 

--- a/apps/berps/package.json
+++ b/apps/berps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@berachain/berps",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "scripts": {
     "dev": "vitepress dev --port 5175",
     "build": "vitepress build",

--- a/apps/core/CHANGELOG.md
+++ b/apps/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @berachain/core
 
+## 1.3.4
+
+### Patch Changes
+
+- Typo correction for Berachain
+
 ## 1.3.3
 
 ### Patch Changes

--- a/apps/core/content/developers/guides/create-helloworld-contract-using-hardhat.md
+++ b/apps/core/content/developers/guides/create-helloworld-contract-using-hardhat.md
@@ -449,7 +449,7 @@ pnpm deploy:localhost;
 
 Now that we can see that the contract can be successfully deployed for a local node, let's configure our deployment script to take advantage of deploying directly to Berachain.
 
-> <b>NOTE:</b> Custom configurations are needed for viem to support custom chains. This will show how set that up with Berchain. When Berachain is public, these extra configurations might not be needed.
+> <b>NOTE:</b> Custom configurations are needed for viem to support custom chains. This will show how set that up with Berachain. When Berachain is public, these extra configurations might not be needed.
 
 **File:** `./scripts/deploy.ts`
 

--- a/apps/core/content/developers/guides/deploy-contract-using-nextjs-walletconnect.md
+++ b/apps/core/content/developers/guides/deploy-contract-using-nextjs-walletconnect.md
@@ -123,7 +123,7 @@ export const projectId = process.env.NEXT_PUBLIC_PROJECT_ID;
 
 const metadata = {
   name: "Berachain Web3Modal",
-  description: "Berchain Web3Modal Example",
+  description: "Berachain Web3Modal Example",
   url: "https://web3modal.com", // origin must match your domain & subdomain
   icons: ["https://avatars.githubusercontent.com/u/96059542"],
 };

--- a/apps/core/content/learn/pol/rewardvaults.md
+++ b/apps/core/content/learn/pol/rewardvaults.md
@@ -14,12 +14,11 @@ A different reward vault contract exists for each PoL-eligible asset
 
 ![Reward Vaults](/assets/reward-vaults.png)
 
-In order to receive BGT, a user must be staking the PoL-eligible asset in its reward vault. The protocol that deployed the reward vault is able to decide how the user acquires the PoL-eligible asset to stake. The idea is that protocols would leverage this to attract liquidity or stimulate activity, and in return award users with the asset they can stake in their vault. 
+In order to receive BGT, a user must be staking the PoL-eligible asset in its reward vault. The protocol that deployed the reward vault is able to decide how the user acquires the PoL-eligible asset to stake. The idea is that protocols would leverage this to attract liquidity or stimulate activity, and in return award users with the asset they can stake in their vault.
 
 1. The user takes some action that results in receiving a PoL-eligible asset, generally referred to as a receipt token.
 2. The user stakes the PoL-eligible asset in the corresponding vault.
 3. The user earns a portion of all the BGT emitted to that vault.
-
 
 **Earning BGT**
 

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@berachain/core",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "scripts": {
     "dev": "vitepress dev --port 5173",
     "build": "vitepress build",


### PR DESCRIPTION
## Description

This PR changes typos in the docs: Berchain -> Berachain

Closes #304

Does it close a specific issue?

Example: Corrected typos

```
Closes #304 
```

## Contribution

- [x] I have followed the [Development Workflow](https://github.com/berachain/docs/blob/main/CONTRIBUTING.md#development-workflow)
- [x] I have read the [CODE OF CONDUCT](https://github.com/berachain/docs/blob/main/CODE_OF_CONDUCT.md)

- [x] I HAVE MADE SURE TO ALLOW MAINTAINERS TO EDIT THIS PULL REQUEST
<img src="https://raw.githubusercontent.com/berachain/docs/refs/heads/main/.github/assets/allow-edits-by-maintainers.png" alt="Allow Maintainers to Edit" width="300px"/>

- [x] I have synced my fork so that it is up to date with the latest changes
<img src="https://raw.githubusercontent.com/berachain/docs/refs/heads/main/.github/assets/synced-fork.png" alt="Synced Fork With Remote Upstream" width="300px"/>

Let us know your wallet address/ENS:

```
0x3eA0675e6F7d8C058E57b436c4832F276B95D4bb
```
