### PR TITLE
docs: fixed broken EIP-713 permit function link

### DIFF
--- a/apps/bend/content/developers/contracts/pool.md
+++ b/apps/bend/content/developers/contracts/pool.md
@@ -33,7 +33,7 @@ function supply(address asset, uint256 amount, address onBehalfOf, uint16 referr
 ### supplyWithPermit
 
 Supply with transfer approval of asset to be supplied done via permit function
-see: https://eips.ethereum.org/EIPS/eip-2612 and https://eips.ethereum.org/EIPS/eip-713
+see: https://eips.ethereum.org/EIPS/eip-2612 and https://eips.ethereum.org/EIPS/eip-712
 
 ```solidity
 function supplyWithPermit(


### PR DESCRIPTION
## Description

Fixed broken link In the [pool.md](https://github.com/berachain/docs/blob/main/apps/bend/content/developers/contracts/pool.md) documentation file, there is an incorrect reference to the permit function in the supplyWithPermit section, which leads to functionality issues. This should be corrected to reflect the proper standard number, EIP-712. 

Closes #318 


## Contribution

- [x] I have followed the [Development Workflow](https://github.com/berachain/docs/blob/main/CONTRIBUTING.md#development-workflow)
- [x] I have read the [CODE OF CONDUCT](https://github.com/berachain/docs/blob/main/CODE_OF_CONDUCT.md)

- [x] I HAVE MADE SURE TO ALLOW MAINTAINERS TO EDIT THIS PULL REQUEST
      <img src="https://raw.githubusercontent.com/berachain/docs/refs/heads/main/.github/assets/allow-edits-by-maintainers.png" alt="Allow Maintainers to Edit" width="300px"/>

- [x] I have synced my fork so that it is up to date with the latest changes
      <img src="https://raw.githubusercontent.com/berachain/docs/refs/heads/main/.github/assets/synced-fork.png" alt="Synced Fork With Remote Upstream" width="300px"/>

Let us know your wallet address/ENS:

```
0x2B3b2710d0181774876A0eE20E4BBAC234188c0C
```
