### PR TITLE
Fixing the `calldata` Specifier in the `mintToPOLFeeCollector` Function

### DIFF
--- a/apps/bend/content/developers/contracts/pool.md
+++ b/apps/bend/content/developers/contracts/pool.md
@@ -601,7 +601,7 @@ function deposit(address asset, uint256 amount, address onBehalfOf, uint16 refer
 ### mintToPOLFeeCollector
 
 ```solidity
-function mintToPOLFeeCollector(address[] assets) external virtual
+function mintToPOLFeeCollector(address[] calldata assets) external virtual
 ```
 
 Mints the assets accrued through the reserve factor to the POL fee collector in the form of aTokens


### PR DESCRIPTION
## Description

An error was found and fixed in the project documentation [pool.md](https://github.com/berachain/docs/blob/main/apps/bend/content/developers/contracts/pool.md) regarding the declaration of the `mintToPOLFeeCollector` function. The original function declaration is as follows: `function mintToPOLFeeCollector(address[] assets) external virtual`

The `calldata` data location specifier needs to be added for the `assets` parameter. The corrected function declaration should be: `function mintToPOLFeeCollector(address[] calldata assets) external virtual`

In Solidity, starting from version 0.5.0, it is mandatory to specify the data location (`memory`, `storage`, or `calldata`) for parameters of array and struct types in external functions. For external functions, it is recommended to use calldata for immutable data as it optimizes gas usage and enhances data processing efficiency.

Omitting the `calldata` specifier for the `assets` parameter in the `mintToPOLFeeCollector` function leads to a compilation error. Therefore, adding `calldata` is necessary to ensure correct compilation and optimal gas usage.


**The proposed change ensures that the `mintToPOLFeeCollector` function compiles correctly and optimizes gas usage during data processing. It is recommended to merge this pull request to rectify the documentation error.**


Does it close a specific issue?

Example:


Closes #328 


## Contribution

- [x] I have followed the [Development Workflow](https://github.com/berachain/docs/blob/main/CONTRIBUTING.md#development-workflow)
- [x] I have read the [CODE OF CONDUCT](https://github.com/berachain/docs/blob/main/CODE_OF_CONDUCT.md)

- [x] I HAVE MADE SURE TO ALLOW MAINTAINERS TO EDIT THIS PULL REQUEST
      <img src="https://raw.githubusercontent.com/berachain/docs/refs/heads/main/.github/assets/allow-edits-by-maintainers.png" alt="Allow Maintainers to Edit" width="300px"/>

- [x] I have synced my fork so that it is up to date with the latest changes
      <img src="https://raw.githubusercontent.com/berachain/docs/refs/heads/main/.github/assets/synced-fork.png" alt="Synced Fork With Remote Upstream" width="300px"/>

Let us know your wallet address/ENS:

```
0x1151f6bfa5f5edc744c522581127d3bb381bde4b
```
