### PR TITLE
docs: ✏️ Fixed syntax errors and type consistency

### DIFF
--- a/apps/bex/content/developers/contracts/dex.md
+++ b/apps/bex/content/developers/contracts/dex.md
@@ -17,7 +17,7 @@ head:
 
 # DEX Contract Interface
 
-The DEX contract (`CrocSwapDex`) is the main entrypoint for interacting with BEX. It acts as a proxy to the various sidecar contracts that implement the different functionalities.
+The DEX contract (`CrocSwapDex`) is the main entry point for interacting with BEX. It acts as a proxy to the various sidecar contracts that implement the different functionalities.
 
 The contract is deployed on bArtio Testnet at: <a :href="config.testnet.dapps.beratrail.url + 'address/' + config.contracts.crocSwapDex.address">{{config.contracts.crocSwapDex.address}}</a>
 
@@ -53,7 +53,7 @@ The primary "vanilla" Solidity method that accepts standard argument types. Beca
 | inBaseQty    | bool    | If true, the qty parameter is denominated in base tokens. If false, it's denominated in quote tokens.                                |
 | qty          | uint128 | The quantity of tokens to swap.                                                                                                      |
 | tip          | uint16  | The tip amount for the relayer executing the swap.                                                                                   |
-| limitPrice   | uint128 | Represents the worse possible price the user is willing to accept. If buying this represents an upper bound.                         |
+| limitPrice   | uint128 | Represents the worst possible price the user is willing to accept. If buying this represents an upper bound.                         |
 | minOut       | uint128 | The minimum amount of output tokens the user is willing to receive.                                                                  |
 | reserveFlags | uint8   | Flags indicating whether to use the user's surplus collateral balance for the base and/or quote token.                               |
 

--- a/apps/bex/content/developers/contracts/surplus-collateral.md
+++ b/apps/bex/content/developers/contracts/surplus-collateral.md
@@ -81,7 +81,7 @@ userCmd(3, abi.encode(
 | Name  | Type    | Description                                                                   |
 | ----- | ------- | ----------------------------------------------------------------------------- |
 | recv  | address | The address to which the surplus collateral will be credited                  |
-| value | uint128 | The total amount to be deposited                                              |
+| value | uint128 | The total amount to be withdrawn                                              |
 | token | address | The address of the ERC20 token being deposited, or address(0) for native BERA |
 
 ## Transfer
@@ -102,5 +102,5 @@ userCmd(3, abi.encode(
 | Name  | Type    | Description                                                                   |
 | ----- | ------- | ----------------------------------------------------------------------------- |
 | recv  | address | The address to which the surplus collateral will be credited                  |
-| value | uint128 | The total amount to be deposited                                              |
+| value | uint128 | The total amount to be transferred                                            |
 | token | address | The address of the ERC20 token being deposited, or address(0) for native BERA |

--- a/apps/bex/content/developers/contracts/swaps.md
+++ b/apps/bex/content/developers/contracts/swaps.md
@@ -55,7 +55,7 @@ userCmd(1, abi.encode(
 | inBaseQty    | bool    | If true, the qty parameter is denominated in base tokens. If false, it's denominated in quote tokens                                                         |
 | qty          | uint128 | The quantity of tokens to swap                                                                                                                               |
 | tip          | uint16  | The tip amount for the relayer executing the swap                                                                                                            |
-| limitPrice   | uint128 | Represents the worse possible price the user is willing to accept. If buying this represents an upper bound.                                                 |
+| limitPrice   | uint128 | Represents the worst possible price the user is willing to accept. If buying this represents an upper bound.                                                 |
 | minOut       | uint128 | The minimum amount of output tokens the user is willing to receive                                                                                           |
 | reserveFlags | uint8   | Flags indicating whether to use the user's surplus collateral balance for the base and/or quote token (see [Type Conventions](/developers/type-conventions)) |
 

--- a/apps/bex/content/developers/guides/multipath-example.md
+++ b/apps/bex/content/developers/guides/multipath-example.md
@@ -81,7 +81,7 @@ This command is routed through `WarmPath.sol` and decoded as follows:
 
 ```solidity
 (uint8 code, address base, address quote, uint256 poolIdx,
-int24 bidTick, int24 askTick, uint128 liq, uint128,limitLower, uint128 limitHigher,
+int24 bidTick, int24 askTick, uint128 liq, uint128 limitLower, uint128 limitHigher,
 uint8 reserveFlags, address lpConduit) =
   abi.decode(input, (uint8,address,address,uint256,int24,int24,uint128,uint128,uint128,uint8,address));
 ```

--- a/apps/bex/content/developers/guides/multiswap.md
+++ b/apps/bex/content/developers/guides/multiswap.md
@@ -46,7 +46,7 @@ struct SwapStep {
 
 | Name     | Type    | Description                                                                                                                         |
 | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| poolIdx  | uin256  | The index of the pool to use for the swap                                                                                           |
+| poolIdx  | uint256 | The index of the pool to use for the swap                                                                                           |
 | base     | address | The token to swap from                                                                                                              |
 | quote    | address | The token to swap to                                                                                                                |
 | isBuy    | bool    | True if the user wants to pay base token and receive quote token. False if the user wants to receive base token and pay quote token |


### PR DESCRIPTION
## Description

corrected incorrectly specified values ​​and after the uint128 type before the limitLower parameter name a comma was mistakenly placed, which leads to a syntax error, I replaced the comma with a space to correctly separate the parameter name type, and also additionally corrected errors and typos in the text

Does it close a specific issue?

Example:

```
Closes 
```

## Contribution

- [x] I have followed the [Development Workflow](https://github.com/berachain/docs/blob/main/CONTRIBUTING.md#development-workflow)
- [x] I have read the [CODE OF CONDUCT](https://github.com/berachain/docs/blob/main/CODE_OF_CONDUCT.md)

- [x] I HAVE MADE SURE TO ALLOW MAINTAINERS TO EDIT THIS PULL REQUEST
      <img src="https://raw.githubusercontent.com/berachain/docs/refs/heads/main/.github/assets/allow-edits-by-maintainers.png" alt="Allow Maintainers to Edit" width="300px"/>

- [x] I have synced my fork so that it is up to date with the latest changes
      <img src="https://raw.githubusercontent.com/berachain/docs/refs/heads/main/.github/assets/synced-fork.png" alt="Synced Fork With Remote Upstream" width="300px"/>

Let us know your wallet address/ENS:

```
0xdFe6c509eB07144240dF388f62b238c5148c5976
```
