### PR TITLE
docs: multiple typographical and grammatical errors across several files

### DIFF
--- a/apps/bex/content/developers/query-contracts/query.md
+++ b/apps/bex/content/developers/query-contracts/query.md
@@ -25,7 +25,7 @@ bArtio Testnet: `{{config.contracts.crocQuery.address}}`
 
 ## Pool Price Functions
 
-The below functions are used to query a pool's instantenous price and prick tick respectively.
+The below functions are used to query a pool's instantaneous price and price tick respectively.
 
 ### queryPrice:
 
@@ -58,7 +58,7 @@ function queryCurveTick (
 ) public view returns (int24)
 ```
 
-**Parameters**;
+**Parameters**
 | Parameter | Type | Description |
 | --------- | ------- | ---------------------------------------------------------------------------------- |
 | base | address | The address of the base-side token in the pool's pair (always the smaller address) |

--- a/apps/bex/content/developers/type-conventions.md
+++ b/apps/bex/content/developers/type-conventions.md
@@ -52,7 +52,7 @@ Signed token quantities indicate the direction of the flow relative to the pool:
 
 All curve prices are represented on-chain as fixed-point Q64.64 representations of the square root. Curve prices always represent the instantaneous exchange rate between the raw tokens and do not account for ERC20 token decimals.
 
-A [TypeScript Library](https://github.com/CrocSwap/sdk/blob/main/src/utils/price.ts) is available for converted between Q64.64 and human-readable prices.
+A [TypeScript Library](https://github.com/CrocSwap/sdk/blob/main/src/utils/price.ts) is available for converting between Q64.64 and human-readable prices.
 
 ### Pool Liquidity Fees
 

--- a/apps/bex/content/learn/guides/fees.md
+++ b/apps/bex/content/learn/guides/fees.md
@@ -19,10 +19,10 @@ Fees are collected on every trade conducted on BEX. A portion of these fees will
 
 Trading fees for LPs are directly compounded inside the pool such that LPs don't need to perform a separate claim transaction. For example, if token prices within an LP's pool are unchanged between deposit and withdrawal, but there have been trades in the interim, the LP will see a higher balance upon withdrawal due to the accumulation of fees.
 
-The portion of fees going to LPs is set at the time of pool creation, the available options being 0.05%, 0.30%, and 1%. The lower fee tiers are generally more appropriate for stable pairings (e.g. stablecoins and blue-chip assets), while the higher fee tiers may be more appropriate for exotic assets, offsetting the risk of LPs holding volatile assets for the duration fo their position.
+The portion of fees going to LPs is set at the time of pool creation, the available options being 0.05%, 0.30%, and 1%. The lower fee tiers are generally more appropriate for stable pairings (e.g. stablecoins and blue-chip assets), while the higher fee tiers may be more appropriate for exotic assets, offsetting the risk of LPs holding volatile assets for the duration of their position.
 
 ![BEX Fees](/assets/bex-fees.png)
 
 ### BGT Fee
 
-An additional 0.1% is levied against traders, which is redirected to BGT stakers as reward for securing the Berachain network.
+An additional 0.1% is levied against traders, which is redirected to BGT stakers as a reward for securing the Berachain network.

--- a/apps/bex/content/learn/guides/swaps.md
+++ b/apps/bex/content/learn/guides/swaps.md
@@ -27,7 +27,7 @@ Users can swap tokens on BEX on bArtio here: {{config.testnet.dapps.bex.url}}/sw
 
 If adequate liquidity exists in a given pair, a swap will most likely be executed as a _single hop_. Single-hop swaps incur less exchange and gas fees, making them the preferred method.
 
-However, When a trade between the input and output token does not provide the best overall price (or the trading pair does not exist as a single pool), BEX can perform a _multi-hop swap_. Multi-hop swaps involve chaining swaps across multiple pools to find the best overall price. The process of finding a cost-efficient multi-hop path is called _routing_.
+However, when a trade between the input and output token does not provide the best overall price (or the trading pair does not exist as a single pool), BEX can perform a _multi-hop swap_. Multi-hop swaps involve chaining swaps across multiple pools to find the best overall price. The process of finding a cost-efficient multi-hop path is called _routing_.
 
 BEX provides an off-chain API for approximately optimal routing. See an <a target="_blank" rel="no-referrer" :href="config.testnet.dapps.bex.apiUrl + 'dex/route?fromAsset=0x7507c1dc16935B82698e4C63f2746A2fCf994dF8&toAsset=0xd6D83aF58a19Cd14eF3CF6fe848C9A4d21e5727c&amount=1000000000000000000'">example here</a>.
 


### PR DESCRIPTION
## Description

1. Correction in `query.md`:

Fixed a typo from "prick" to "price" in the description of the query functions. This change eliminates the confusion related to querying price data.

2. Formatting fix in `query.md`:

Removed an unnecessary semicolon in the "Parameters" heading, restoring proper formatting and ensuring uniformity across the section.

3. Update in `type-conventions.md`:

Changed "converted" to "converting" for more accurate contextual usage in the TypeScript Library description.

Corrections in `fees.md`:

Replaced "fo" with "for" to fix a typographical error.
Modified "as reward" to "as a reward" for grammatical correctness.

Grammar fix in `swaps.md`:

Corrected "When" to "when" for proper sentence structure, aligning it with the style used throughout the documentation.

These changes making docs more understandable and error-free for developers.


Does it close a specific issue?

Example:


Closes #336 


## Contribution

- [x] I have followed the [Development Workflow](https://github.com/berachain/docs/blob/main/CONTRIBUTING.md#development-workflow)
- [x] I have read the [CODE OF CONDUCT](https://github.com/berachain/docs/blob/main/CODE_OF_CONDUCT.md)

- [x] I HAVE MADE SURE TO ALLOW MAINTAINERS TO EDIT THIS PULL REQUEST
      <img src="https://raw.githubusercontent.com/berachain/docs/refs/heads/main/.github/assets/allow-edits-by-maintainers.png" alt="Allow Maintainers to Edit" width="300px"/>

- [x] I have synced my fork so that it is up to date with the latest changes
      <img src="https://raw.githubusercontent.com/berachain/docs/refs/heads/main/.github/assets/synced-fork.png" alt="Synced Fork With Remote Upstream" width="300px"/>

Let us know your wallet address/ENS:

```
0x3502a4EC2fa7797A1F4ef472b7485D9491F6C231
```
