### PR TITLE
Resolve Incorrect Ownable Constructor Arguments in StakingToken

### DIFF
--- a/apps/core/content/developers/guides/advanced-pol.md
+++ b/apps/core/content/developers/guides/advanced-pol.md
@@ -71,7 +71,7 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract StakingToken is ERC20, Ownable {
-    constructor() ERC20("StakingToken", "STK") Ownable(msg.sender) {}
+    constructor() ERC20("StakingToken", "STK") Ownable() {}
 
     function mint(address to, uint256 amount) external onlyOwner {
         _mint(to, amount);


### PR DESCRIPTION
## Description

In the `StakingToken` contract constructor, `Ownable(msg.sender)` is used incorrectly. In OpenZeppelin's `Ownable` contract, the constructor does not accept any arguments and automatically sets the owner to the address that deploys the contract. Therefore, `Ownable()` should be used without any arguments.

**Original Code:**
`constructor() ERC20("StakingToken", "STK") Ownable(msg.sender) {}`

Attempting to pass `msg.sender` to the `Ownable` constructor will result in a compilation error because `Ownable` does not expect any arguments.

**Corrected Code:**
`constructor() ERC20("StakingToken", "STK") Ownable() {}`

Properly invoking the `Ownable` constructor without arguments ensures that the contract compiles successfully.

*Avoiding Errors:* Manually passing `msg.sender` can lead to unforeseen errors or undesired behavior, especially if the `Ownable` constructor changes in future versions of the library.






## Contribution

- [x] I have followed the [Development Workflow](https://github.com/berachain/docs/blob/main/CONTRIBUTING.md#development-workflow)
- [x] I have read the [CODE OF CONDUCT](https://github.com/berachain/docs/blob/main/CODE_OF_CONDUCT.md)

- [x] I HAVE MADE SURE TO ALLOW MAINTAINERS TO EDIT THIS PULL REQUEST
      <img src="https://raw.githubusercontent.com/berachain/docs/refs/heads/main/.github/assets/allow-edits-by-maintainers.png" alt="Allow Maintainers to Edit" width="300px"/>

- [x] I have synced my fork so that it is up to date with the latest changes
      <img src="https://raw.githubusercontent.com/berachain/docs/refs/heads/main/.github/assets/synced-fork.png" alt="Synced Fork With Remote Upstream" width="300px"/>

Let us know your wallet address/ENS:

```
0x4bb12D736C469eBaF5939d639A9A4a5621164AcB
```
