### PR TITLE
Removing BEND/BERPs sections on Core docs

### DIFF
--- a/apps/core/.vitepress/sidebar.ts
+++ b/apps/core/.vitepress/sidebar.ts
@@ -64,12 +64,10 @@ const SIDEBAR = {
     {
       text: "Native dApps",
       items: [
-        { text: "BeraSwap", link: "/learn/dapps/beraswap" },
-        { text: "Bend", link: "/learn/dapps/bend" },
-        { text: "Berps", link: "/learn/dapps/berps" },
         { text: "BeraHub", link: "/learn/dapps/berahub" },
-        { text: "Faucet", link: "/learn/dapps/faucet" },
+        { text: "BeraSwap", link: "/learn/dapps/beraswap" },
         { text: "Honey Swap", link: "/learn/dapps/honey-swap" },
+        { text: "Faucet", link: "/learn/dapps/faucet" },
         {
           text: `${constants.mainnet.dapps.berascan.name}`,
           link: `/learn/dapps/berascan`,


### PR DESCRIPTION
## Description

What changes are made in this PR? Is it a feature or a bug fix?
Removing BEND/BERPs sections
Does it close a specific issue?

## Contribution

- [ ] I have followed the [Development Workflow](https://github.com/berachain/docs/blob/main/CONTRIBUTING.md#development-workflow)
- [ ] I have read the [CODE OF CONDUCT](https://github.com/berachain/docs/blob/main/CODE_OF_CONDUCT.md)

- [ ] I HAVE MADE SURE TO ALLOW MAINTAINERS TO EDIT THIS PULL REQUEST
      <img src="https://raw.githubusercontent.com/berachain/docs/refs/heads/main/.github/assets/allow-edits-by-maintainers.png" alt="Allow Maintainers to Edit" width="300px"/>

- [ ] I have synced my fork so that it is up to date with the latest changes
      <img src="https://raw.githubusercontent.com/berachain/docs/refs/heads/main/.github/assets/synced-fork.png" alt="Synced Fork With Remote Upstream" width="300px"/>

Let us know your wallet address/ENS:

```
0xYourAddress
```
