### PR TITLE
simplify validator guide followup steps

### DIFF
--- a/apps/core/content/nodes/guides/validator.md
+++ b/apps/core/content/nodes/guides/validator.md
@@ -273,26 +273,10 @@ Make a PR to the following GitHub repository to add your validator to the valida
 
 [https://github.com/berachain/metadata](https://github.com/berachain/metadata)
 
-If you have a logo you'd like us to use, attach it to the pull request.
+If you have a logo you'd like us to use, attach it to the pull request according to the instructions in [https://github.com/berachain/metadata/blob/main/CONTRIBUTING.md](CONTRIBUTING).
 
 ### Step 2 - Send Berachain Team Wallet Addresses
 
-Reach out to the Berachain validator relations team with your validator's CometBFT public keys to help us find you if your node begins having trouble, hopefully _before_ it gets slashed. If you aren't known to the validator relations team, speak up on the #node-support channel on our Discord.
+Reach out to the Berachain validator relations team with your validator's CometBFT public keys to help us find you if your node begins having trouble, hopefully _before_ it gets slashed. If you aren't known to the validator relations team, speak up on the #node-support channel on our Discord. We provide dedicated support channels for mainnet validators. 
 
-### Step 3 - Send Berachain Your CometBFT Address
-
-Reach out to the Berachain validator relations team with your CometBFT address found in your `priv_validator_key.json` file. If you aren't known to us, poke your head up on the #node-support channel on our Discord.
-
-This is the 40 character address found in your `priv_validator_key.json` file.
-
-You can get this by looking at the file or running the following:
-
-```bash
-# FROM: /
-
-# OR /path/to/$HOME/config/priv_validator_key.json
-cat ./.beacond/config/priv_validator_key.json | jq -r ".address";
-
-# [Expected Similar Address]
-# A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0
-```
+Send us the output of `beacond deposit validator-keys`.

--- a/apps/core/content/nodes/quickstart.md
+++ b/apps/core/content/nodes/quickstart.md
@@ -114,21 +114,16 @@ The key network parameters for Berachain mainnet are downloaded by `fetch-berach
 ./fetch-berachain-params.sh;
 
 # [Expected Output for mainnet]:
-# 6e4179e38e11696f8402cd5f8e872726  seed-data/app.toml
-# 1021d186aae506482deb760e63143ae6  seed-data/config.toml
-# 3caf21bb2134ed4c1970c904d2128d30  seed-data/el-peers.txt
-# cd3a642dc78823aea8d80d5239231557  seed-data/eth-genesis.json
-# c66dbea5ee3889e1d0a11f856f1ab9f0  seed-data/genesis.json
-# 5d0d482758117af8dfc20e1d52c31eef  seed-data/kzg-trusted-setup.json
+# cd3a642dc78823aea8d80d5239231557  seed-data-80094/eth-genesis.json
+# c0b7dc21e089f9074d97957526fcd08f  seed-data-80094/eth-nether-genesis.json
+# c66dbea5ee3889e1d0a11f856f1ab9f0  seed-data-80094/genesis.json
+# 5d0d482758117af8dfc20e1d52c31eef  seed-data-80094/kzg-trusted-setup.json
 
 # [Expected Output for bepolia]
-# 6e4179e38e11696f8402cd5f8e872726  seed-data/app.toml
-# 65313bc44bc810da50bf0dac696219fe  seed-data/config.toml
-# a14b14eca398d857344d1ce86c848352  seed-data/el-peers.txt
-# 7ac0e3756f7e3d0af36d023f9e6cfd0c  seed-data/eth-genesis.json
-# ec67ba1beb73cc9042000e5dd21b5f72  seed-data/eth-nether-genesis.json
-# a24fb9c7ddf3ebd557300e989d44b619  seed-data/genesis.json
-# 5d0d482758117af8dfc20e1d52c31eef  seed-data/kzg-trusted-setup.json
+# 7ac0e3756f7e3d0af36d023f9e6cfd0c  seed-data-80069/eth-genesis.json
+# ec67ba1beb73cc9042000e5dd21b5f72  seed-data-80069/eth-nether-genesis.json
+# a24fb9c7ddf3ebd557300e989d44b619  seed-data-80069/genesis.json
+# 5d0d482758117af8dfc20e1d52c31eef  seed-data-80069/kzg-trusted-setup.json
 
 ```
 


### PR DESCRIPTION
- use `beacond deposit validator-keys`
- specifically call out metadata contributing guidelines
- 