### PR TITLE
fix: 🐛 Fixed incorrect wording on PoL changelog

### DIFF
--- a/apps/core/content/learn/pol/changelog.md
+++ b/apps/core/content/learn/pol/changelog.md
@@ -8,7 +8,7 @@
 1. New Maximum of 3 incentives per reward vault
 2. Block Reward Emissions have been modified in line with the targeted inflation rate of 10%. Updated constants are found on-chain via [BlockRewardController](https://berascan.com/address/0x1AE7dD7AE06F6C58B4524d9c1f816094B1bcCD8e) and described in [Block Production & Emissions](/learn/pol/bgtmath).
 
-3. Auto-Incentivizer: fees from foundation vaults will use the fees to automatically offer incentives
+3. Auto-Incentivizer: fees from default cutting board BEX Reward Vaults will use the fees to automatically offer incentives
 
 ![Berachain Auto-Incentivizer](/assets/auto-incentivizer.png)
 


### PR DESCRIPTION
## Description

Adjusted wording for PoL changelog.

## Contribution

- [x] I have followed the [Development Workflow](https://github.com/berachain/docs/blob/main/CONTRIBUTING.md#development-workflow)
- [x] I have read the [CODE OF CONDUCT](https://github.com/berachain/docs/blob/main/CODE_OF_CONDUCT.md)

- [x] I HAVE MADE SURE TO ALLOW MAINTAINERS TO EDIT THIS PULL REQUEST

<img src="https://res.cloudinary.com/duv0g402y/image/upload/v1739534789/docs/ugpjqmh14xju95h8ff6a.png" alt="Allow Maintainers to Edit" width="300px"/>

- [x] I have synced my fork so that it is up to date with the latest changes

<img src="https://res.cloudinary.com/duv0g402y/image/upload/v1739534800/docs/sng9bnmfs6crqnhr9i83.png" alt="Synced Fork With Remote Upstream" width="300px"/>

Let us know your wallet address/ENS:

```
codingwithmanny.eth
codingwithmanny.bera
```
