### PR TITLE
rename /learn/pol/bgtmath to /learn/pol/blockrewards

### DIFF
--- a/apps/core/.vitepress/sidebar.ts
+++ b/apps/core/.vitepress/sidebar.ts
@@ -31,7 +31,7 @@ const SIDEBAR = {
       items: [
         { text: "Overview", link: "/learn/pol/" },
         { text: "Participants", link: "/learn/pol/participants" },
-        { text: "Block Production/Emissions", link: "/learn/pol/bgtmath" },
+        { text: "Block Rewards", link: "/learn/pol/blockrewards" },
         { text: "Reward Vaults", link: "/learn/pol/rewardvaults" },
         { text: "Incentives", link: "/learn/pol/incentives" },
         {

--- a/apps/core/content/developers/index.md
+++ b/apps/core/content/developers/index.md
@@ -7,7 +7,7 @@ Berachain's Proof of Liquidity (PoL) mechanism can be broken down into two broad
 
 ## BGT Distribution
 
-As discussed in [Block Production](/learn/pol/bgtmath), $BGT emissions stem from the block production process. The variable component of $BGT emissions per block is determined by the proposing validator's $BGT delegation (also referred to as "boost").
+As discussed in [Block Rewards](/learn/pol/blockrewards), $BGT emissions stem from the block production process. The variable component of $BGT emissions per block is determined by the proposing validator's $BGT delegation (also referred to as "boost").
 
 ### Distributor
 

--- a/apps/core/content/learn/pol/blockrewards.md
+++ b/apps/core/content/learn/pol/blockrewards.md
@@ -2,7 +2,7 @@
   import config from '@berachain/config/constants.json';
 </script>
 
-# Block Production and Emissions
+# Block Production & Rewards
 
 Proof-of-Liquidity governs block rewards and token emissions on Berachain using the `$BGT` token. This page explains the mathematical principles behind validator selection, block rewards, and emissions calculations.
 
@@ -15,6 +15,8 @@ The network maintains an active set of **{{ config.mainnet.validatorActiveSetSiz
 - Stake limitations per validator:
   - Minimum: {{ config.mainnet.minEffectiveBalance }} `$BERA`
   - Maximum: {{ config.mainnet.maxEffectiveBalance }} `$BERA`
+
+A given Validator's probability of selection for producing a block is the proportion of its stake's weight to the total stakes of the active set.
 
 ## $BGT Emissions Structure
 

--- a/apps/core/content/learn/pol/changelog.md
+++ b/apps/core/content/learn/pol/changelog.md
@@ -6,7 +6,7 @@
 
 **Proof of Liquidity 1.2:**
 1. New Maximum of 3 incentives per reward vault
-2. Block Reward Emissions have been modified in line with the targeted inflation rate of 10%. Updated constants are found on-chain via [BlockRewardController](https://berascan.com/address/0x1AE7dD7AE06F6C58B4524d9c1f816094B1bcCD8e) and described in [Block Production & Emissions](/learn/pol/bgtmath).
+2. Block Reward Emissions have been modified in line with the targeted inflation rate of 10%. Updated constants are found on-chain via [BlockRewardController](https://berascan.com/address/0x1AE7dD7AE06F6C58B4524d9c1f816094B1bcCD8e) and described in [Block Rewards](/learn/pol/blockrewards).
 
 3. Auto-Incentivizer: fees from default cutting board BEX Reward Vaults will use the fees to automatically offer incentives
 

--- a/apps/core/content/learn/pol/incentives.md
+++ b/apps/core/content/learn/pol/incentives.md
@@ -17,7 +17,7 @@ Validators can capture Incentives offered by Whitelisted Reward Vaults by direct
 The distribution of Incentives follows this process:
 
 1. A **User** Boosts (by associating their $BGT with a validator) to increase a validator's $BGT emissions they receive when proposing a block.
-2. A **Validator** receives block rewards in the form of $BGT emissions, where the amount is influenced by Boost (see [\$BGT Emissions Per Block](/learn/pol/bgtmath#bgt-emissions-per-block)), and directs emissions toward Whitelisted Reward Vaults chosen by the validator.
+2. A **Validator** receives block rewards in the form of $BGT emissions, where the amount is influenced by Boost (see [\$BGT Emissions Per Block](/learn/pol/blockrewards#bgt-emissions-per-block)), and directs emissions toward Whitelisted Reward Vaults chosen by the validator.
 3. A **Protocol** can offer up to two different Incentive Tokens to encourage validators to direct $BGT emissions to their Reward Vault.
 4. When the $BGT block reward emissions are distributed:
    - The validator's operator address receives a commission (percentage of all the Incentive Tokens captured).

--- a/apps/core/content/learn/pol/index.md
+++ b/apps/core/content/learn/pol/index.md
@@ -16,7 +16,7 @@ Berachain's Active Set of validators (validators participating in consensus) is 
 
 The size of a validator's `$BGT` block reward is determined by their Boost, which is a percentage calculated from the validator's `$BGT` boost divided by the total `$BGT` boosted to all validators. Boosts are obtained when `$BGT` holders delegate to validators.
 
-Learn more about how emissions are calculated on the [emissions page](./bgtmath.md).
+Learn more about how emissions are calculated on the [emissions page](./blockrewards.md).
 
 ## PoL Lifecycle
 
@@ -24,7 +24,7 @@ Learn more about how emissions are calculated on the [emissions page](./bgtmath.
 
 ### 1. Validator Lifecycle
 
-The journey begins when a Prospective Validator stakes their `$BERA` as a security bond (①). Validators are chosen to propose blocks with a probability proportional to their staked amount (②). For each block proposed, the validator receives both a base emission and a variable reward emission based on their boost percentage (③) (see [emissions](./bgtmath.md)).
+The journey begins when a Prospective Validator stakes their `$BERA` as a security bond (①). Validators are chosen to propose blocks with a probability proportional to their staked amount (②). For each block proposed, the validator receives both a base emission and a variable reward emission based on their boost percentage (③) (see [emissions](./blockrewards.md)).
 
 ### 2. Reward Distribution
 

--- a/apps/core/content/learn/pol/rewardvaults.md
+++ b/apps/core/content/learn/pol/rewardvaults.md
@@ -35,7 +35,7 @@ After staking assets in a Reward Vault, users are free to claim their earned rew
 
 ## $BGT Flow
 
-When a validator is chosen to propose a block, they direct a portion of their `$BGT` emissions to specific Reward Vaults of their choice. To learn more about how `$BGT` is calculated in block production, check out the docs on [emissions](/learn/pol/bgtmath).
+When a validator is chosen to propose a block, they direct a portion of their `$BGT` emissions to specific Reward Vaults of their choice. To learn more about how `$BGT` is calculated in block production, check out the docs on [block rewards](/learn/pol/blockrewards).
 
 ## Incentives
 

--- a/apps/core/content/learn/pol/tokens/bera.md
+++ b/apps/core/content/learn/pol/tokens/bera.md
@@ -38,4 +38,4 @@ The `$BERA` token serves two main purposes on the Berachain network:
 
 Validators stake `$BERA` to operate a validator. Within the active set, the more `$BERA` a validator has staked, the more frequently they are chosen to propose blocks. A validator's probability of block production is directly proportional to their share of the total staked `$BERA`. The economic value of all staked `$BERA` tokens forms the economic security of the chain, with [$BGT](/learn/pol/tokens/bgt) dynamics controlling its inflation.
 
-To learn more about how `$BERA` staking affects block production and emissions, see [Block Production](/learn/pol/bgtmath.md).
+To learn more about how `$BERA` staking affects block production and emissions, see [Block Rewards](/learn/pol/blockrewards.md).

--- a/apps/core/content/learn/pol/tokens/bgt.md
+++ b/apps/core/content/learn/pol/tokens/bgt.md
@@ -53,7 +53,7 @@ Users can claim accumulated `$BGT` from Berahub.
 
 #### Boost A Validator For Incentives
 
-Users can select validators to "boost" with their `$BGT`, increasing the validator's [reward emission](/learn/pol/bgtmath). The amount of [Incentives](/learn/pol/incentives) earned is determined by validators' aggregate boost. These incentives are returned to the `$BGT` holders who boosted the validator.
+Users can select validators to "boost" with their `$BGT`, increasing the validator's [block rewards](/learn/pol/blockrewards). The amount of [Incentives](/learn/pol/incentives) earned is determined by validators' aggregate boost. These incentives are returned to the `$BGT` holders who boosted the validator.
 
 #### dApp Fees
 

--- a/apps/core/vercel.json
+++ b/apps/core/vercel.json
@@ -5,6 +5,10 @@
   "cleanUrls": true,
   "redirects": [
     {
+      "source": "/learn/pol/bgtmath",
+      "destination": "/learn/pol/blockrewards"
+    },
+    {
       "source": "/learn/dapps/swap",
       "destination": "/learn/dapps/bex"
     },


### PR DESCRIPTION
standardize terminology throughout

wondering about:
- [ ] ?  remove all uses of 'emissions' in text