### PR TITLE
fix to publish berascan testnet URL

### DIFF
--- a/apps/core/content/developers/network-configurations.md
+++ b/apps/core/content/developers/network-configurations.md
@@ -92,7 +92,7 @@ With the testnet, you can:
     <thead><tr><th>Name</th><th>URL</th></tr></thead>
     <tbody>
           <tr>
-            <td><a :href="item.url">{{ item.name }}</a>
+            <td><a :href="item.url">{{ item.name }}</a></td>
             <td>{{ item.url }}</td>
           </tr>
     </tbody>

--- a/apps/core/content/developers/network-configurations.md
+++ b/apps/core/content/developers/network-configurations.md
@@ -87,7 +87,17 @@ With the testnet, you can:
 
 ### Bepolia Testnet dApps
 
-| Name                                                                                                        | URL                                                                                     |
-| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| <a :href="config.bepolia.dapps.faucet.url" target="_blank">{{ config.bepolia.dapps.faucet.name }}</a>       | <ClientOnly><CopyToClipboard :text="config.bepolia.dapps.faucet.url" /></ClientOnly>    |
-| <a :href="config.bepolia.dapps.beratrail.url" target="_blank">{{ config.bepolia.dapps.beratrail.name }}</a> | <ClientOnly><CopyToClipboard :text="config.bepolia.dapps.beratrail.url" /></ClientOnly> |
+
+
+<template v-for="(item) in config['bepolia']['dapps']">
+  <table>
+    <thead><tr><th>Name</th><th>URL</th></tr></thead>
+    <tbody>
+          <tr>
+            <td><a :href="item.url">{{ item.name }}</a>
+            <td>{{ item.url }}</td>
+          </tr>
+    </tbody>
+  </table>
+</template>
+

--- a/apps/core/content/developers/network-configurations.md
+++ b/apps/core/content/developers/network-configurations.md
@@ -87,8 +87,6 @@ With the testnet, you can:
 
 ### Bepolia Testnet dApps
 
-
-
 <template v-for="(item) in config['bepolia']['dapps']">
   <table>
     <thead><tr><th>Name</th><th>URL</th></tr></thead>
@@ -100,4 +98,3 @@ With the testnet, you can:
     </tbody>
   </table>
 </template>
-

--- a/packages/config/constants.json
+++ b/packages/config/constants.json
@@ -17,7 +17,7 @@
       },
       "berascan": {
         "name": "BeraScan Block Explorer",
-        "url": "#"
+        "url": "https://testnet.berascan.com/"
       },
       "hub": {
         "name": "Bepolia Hub",


### PR DESCRIPTION
- changed 'network configurations' page to automatically use dapps in the config
- updated the berascan address for testnet
