### PR TITLE
fix: ensure PoL contract addresses are consistent across networks

### DIFF
--- a/packages/config/constants.json
+++ b/packages/config/constants.json
@@ -166,14 +166,14 @@
       "bgtIncentiveFeeCollector": {
         "name": "BGTIncentiveFeeCollector",
         "bepolia-address": "0x1984Baf659607Cc5f206c55BB3B00eb3E180190B",
-        "mainnet-address": "",
+        "mainnet-address": "0x1984Baf659607Cc5f206c55BB3B00eb3E180190B",
         "abi": "",
         "docsUrl": "/developers/contracts/bgt-incentive-fee-collector"
       },
       "wberaStakerVault": {
         "name": "WBERAStakerVault",
         "bepolia-address": "0x118D2cEeE9785eaf70C15Cd74CD84c9f8c3EeC9a",
-        "mainnet-address": "",
+        "mainnet-address": "0x118D2cEeE9785eaf70C15Cd74CD84c9f8c3EeC9a",
         "abi": "",
         "docsUrl": "/developers/contracts/wbera-staker-vault"
       },


### PR DESCRIPTION
- Set wberaStakerVault mainnet address to match testnet address
- Set bgtIncentiveFeeCollector mainnet address to match testnet address
- Ensures SWBERA vault and incentive fee collector have same addresses for both mainnet and testnet
- Follows the pattern of other PoL contracts that use identical addresses across networks

## Description

What changes are made in this PR? Is it a feature or a bug fix?

Does it close a specific issue?

Example:

```
Closes #1
```

## Checklist

<!-- Mark the appropriate options with an "x" -->

- [ ] I have followed the [Development Workflow](https://github.com/berachain/docs/blob/main/CONTRIBUTING.md#development-workflow)
- [ ] I have read the [CODE OF CONDUCT](https://github.com/berachain/docs/blob/main/CODE_OF_CONDUCT.md)
- [ ] I HAVE MADE SURE TO ALLOW MAINTAINERS TO EDIT THIS PULL REQUEST

<img src="https://res.cloudinary.com/duv0g402y/image/upload/v1739534789/docs/ugpjqmh14xju95h8ff6a.png" alt="Allow Maintainers to Edit" width="300px"/>

- [ ] I have synced my fork so that it is up to date with the latest changes

<img src="https://res.cloudinary.com/duv0g402y/image/upload/v1739534800/docs/sng9bnmfs6crqnhr9i83.png" alt="Synced Fork With Remote Upstream" width="300px"/>
