### PR TITLE
Add updated column to genesis files

### DIFF
--- a/apps/core/content/nodes/guides/august-2025-upgrade.md
+++ b/apps/core/content/nodes/guides/august-2025-upgrade.md
@@ -78,10 +78,10 @@ If you duplicate your installation to test, don't duplicate these identity files
 | Mainnet & Bepolia | [Bera-Reth v1.0.0](https://github.com/berachain/bera-reth/releases/tag/v1.0.0)           | August 13    |
 | Mainnet & Bepolia | [Beacon-Kit v1.3.0](https://github.com/berachain/beacon-kit/releases/tag/v1.3.0)         | August 13    |
 
-| File                           | Download link & md5 hash                                                                                                                           |
-| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Bepolia Bera-Reth/Geth Genesis | [b659cbef86a6eded371d8e443abf2c0b](https://raw.githubusercontent.com/berachain/beacon-kit/refs/heads/main/testing/networks/80069/eth-genesis.json) |
-| Mainnet Bera-Reth/Geth Genesis | [f3ec1202993b1b69a9c7ad30643856ce](https://raw.githubusercontent.com/berachain/beacon-kit/refs/heads/main/testing/networks/80094/eth-genesis.json) |
+| File                           | Download link & md5 hash                                                                                                                           | Updated   |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| Bepolia Bera-Reth/Geth Genesis | [b659cbef86a6eded371d8e443abf2c0b](https://raw.githubusercontent.com/berachain/beacon-kit/refs/heads/main/testing/networks/80069/eth-genesis.json) | August 15 |
+| Mainnet Bera-Reth/Geth Genesis | [f3ec1202993b1b69a9c7ad30643856ce](https://raw.githubusercontent.com/berachain/beacon-kit/refs/heads/main/testing/networks/80094/eth-genesis.json) | August 15 |
 
 ## Confirm upgrade
 


### PR DESCRIPTION
## Description

This PR adds an "Updated" column to the genesis files table in `docs/apps/core/content/nodes/guides/august-2025-upgrade.md`. Both Bepolia and Mainnet Bera-Reth/Geth Genesis files now display "August 15" in this new column. This enhancement provides users with clear visibility on when the genesis files were last updated, ensuring they are using the most current versions.

## Checklist

<!-- Mark the appropriate options with an "x" -->

- [ ] I have followed the [Development Workflow](https://github.com/berachain/docs/blob/main/CONTRIBUTING.md#development-workflow)
- [ ] I have read the [CODE OF CONDUCT](https://github.com/berachain/docs/blob/main/CODE_OF_CONDUCT.md)
- [ ] I HAVE MADE SURE TO ALLOW MAINTAINERS TO EDIT THIS PULL REQUEST

<img src="https://res.cloudinary.com/duv0g402y/image/upload/v1739534789/docs/ugpjqmh14xju95h8ff6a.png" alt="Allow Maintainers to Edit" width="300px"/>

- [ ] I have synced my fork so that it is up to date with the latest changes

<img src="https://res.cloudinary.com/duv0g402y/image/upload/v1739534800/docs/sng9bnmfs6crqnhr9i83.png" alt="Synced Fork With Remote Upstream" width="300px"/>

---
<a href="https://cursor.com/background-agent?bcId=bc-94e863ba-f34a-4dc0-9135-a4137100a2e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-94e863ba-f34a-4dc0-9135-a4137100a2e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

