### PR TITLE
Update provider listing: dRPC → dRPC NodeCloud

### DIFF
--- a/apps/core/content/developers/developer-tools.md
+++ b/apps/core/content/developers/developer-tools.md
@@ -43,7 +43,7 @@ Since Berachain is EVM-compatible, if you're familiar with creating dApps on oth
 - [Alchemy](https://docs.alchemy.com/reference/berachain-api-quickstart)
 - [BlockPI](https://blockpi.io/)
 - [Chainstack](https://chainstack.com/build-better-with-berachain/)
-- [DRPC](https://drpc.org/chainlist/berachain)
+- [dRPC NodeCloud](https://drpc.org/chainlist/berachain)
 - [Grove](https://grove.city)
 - [Envio](https://envio.dev)
 - [Enigma](https://enigma-validator.com/services)


### PR DESCRIPTION
## Description

What changes are made in this PR? Is it a feature or a bug fix?

Updated the dRPC provider name to reflect current branding and service scope.

- Updated name: "dRPC" → "dRPC NodeCloud"
- More accurate value proposition for the Berachain ecosystem
- Updated link to: https://drpc.org/chainlist/berachain

Does it close a specific issue?

Example:

```
Closes #1
```

## Checklist

<!-- Mark the appropriate options with an "x" -->

- [ x] I have followed the [Development Workflow](https://github.com/berachain/docs/blob/main/CONTRIBUTING.md#development-workflow)
- [ x] I have read the [CODE OF CONDUCT](https://github.com/berachain/docs/blob/main/CODE_OF_CONDUCT.md)
- [ x] I HAVE MADE SURE TO ALLOW MAINTAINERS TO EDIT THIS PULL REQUEST

<img src="https://res.cloudinary.com/duv0g402y/image/upload/v1739534789/docs/ugpjqmh14xju95h8ff6a.png" alt="Allow Maintainers to Edit" width="300px"/>

- [ x] I have synced my fork so that it is up to date with the latest changes

<img src="https://res.cloudinary.com/duv0g402y/image/upload/v1739534800/docs/sng9bnmfs6crqnhr9i83.png" alt="Synced Fork With Remote Upstream" width="300px"/>
